### PR TITLE
Correct editing bug when editing as group owner

### DIFF
--- a/actions/edit.php
+++ b/actions/edit.php
@@ -31,6 +31,7 @@ if (!empty($title)) {
 		$entity = new Newsletter();
 		$entity->owner_guid = $container_guid;
 		$entity->container_guid = $container_guid;
+		$entity->access_id = $access_id;
 		
 		$entity->status = "concept";
 		


### PR DESCRIPTION
When creating a new newsletter as a non-admin user (ie. group admin or group operator), creation fails with "IOException:UnableToSaveNew" exception.

I haven't checked deeply enough to tell why this doesn't happen when creating it with an admin user, but anyway this small patch corrects it by setting the access_id before saving (which is required by ElggEntity->save() function).